### PR TITLE
Let muzzle plugin find helper classes

### DIFF
--- a/instrumentation/nocode/build.gradle.kts
+++ b/instrumentation/nocode/build.gradle.kts
@@ -1,10 +1,14 @@
 plugins {
   id("splunk.instrumentation-conventions")
+  id("splunk.muzzle-conventions")
 }
 
 dependencies {
+  compileOnly(project(":custom"))
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
   compileOnly("org.snakeyaml:snakeyaml-engine:2.8")
+
+  add("codegen", project(":bootstrap"))
 }
 
 tasks.withType<Test>().configureEach {

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInitializer.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInitializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.opentelemetry.instrumentation.nocode;
+
+import static io.opentelemetry.sdk.autoconfigure.AutoConfigureUtil.getConfig;
+
+import com.google.auto.service.AutoService;
+import com.splunk.opentelemetry.javaagent.bootstrap.nocode.NocodeRules;
+import io.opentelemetry.javaagent.tooling.BeforeAgentListener;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+
+@AutoService(BeforeAgentListener.class)
+public class NocodeInitializer implements BeforeAgentListener {
+
+  @Override
+  public void beforeAgent(AutoConfiguredOpenTelemetrySdk autoConfiguredOpenTelemetrySdk) {
+    ConfigProperties config = getConfig(autoConfiguredOpenTelemetrySdk);
+    YamlParser yp = new YamlParser(config);
+    NocodeRules.setGlobalRules(yp.getInstrumentationRules());
+  }
+}

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeModule.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeModule.java
@@ -21,7 +21,6 @@ import com.splunk.opentelemetry.javaagent.bootstrap.nocode.NocodeRules;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @AutoService(InstrumentationModule.class)
@@ -29,8 +28,6 @@ public final class NocodeModule extends InstrumentationModule {
 
   public NocodeModule() {
     super("nocode");
-    YamlParser yp = new YamlParser();
-    NocodeRules.setGlobalRules(yp.getInstrumentationRules());
   }
 
   @Override
@@ -39,18 +36,17 @@ public final class NocodeModule extends InstrumentationModule {
     for (NocodeRules.Rule rule : NocodeRules.getGlobalRules()) {
       answer.add(new NocodeInstrumentation(rule));
     }
+    // ensure that there is at least one instrumentation so that muzzle reference collection could
+    // work
+    if (answer.isEmpty()) {
+      answer.add(new NocodeInstrumentation(null));
+    }
     return answer;
   }
 
   @Override
-  public List<String> getAdditionalHelperClassNames() {
-    return Arrays.asList(
-        "com.splunk.opentelemetry.instrumentation.nocode.JSPS",
-        "com.splunk.opentelemetry.instrumentation.nocode.NocodeSingletons",
-        "com.splunk.opentelemetry.instrumentation.nocode.NocodeAttributesExtractor",
-        "com.splunk.opentelemetry.instrumentation.nocode.NocodeMethodInvocation",
-        "com.splunk.opentelemetry.instrumentation.nocode.NocodeSpanKindExtractor",
-        "com.splunk.opentelemetry.instrumentation.nocode.NocodeSpanNameExtractor");
+  public boolean isHelperClass(String className) {
+    return className.startsWith("com.splunk.opentelemetry.instrumentation");
   }
 
   @Override

--- a/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeSingletons.java
+++ b/instrumentation/nocode/src/main/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeSingletons.java
@@ -25,14 +25,12 @@ public class NocodeSingletons {
   static {
     INSTRUMENTER =
         Instrumenter.<NocodeMethodInvocation, Void>builder(
-                GlobalOpenTelemetry.get(),
-                "com.splunk.opentelemetry.instrumentation.nocode",
-                new NocodeSpanNameExtractor())
+                GlobalOpenTelemetry.get(), "com.splunk.nocode", new NocodeSpanNameExtractor())
             .addAttributesExtractor(new NocodeAttributesExtractor())
             .buildInstrumenter(new NocodeSpanKindExtractor());
   }
 
-  public static Instrumenter<NocodeMethodInvocation, Void> instrumentor() {
+  public static Instrumenter<NocodeMethodInvocation, Void> instrumenter() {
     return INSTRUMENTER;
   }
 }

--- a/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentationTest.java
+++ b/instrumentation/nocode/src/test/java/com/splunk/opentelemetry/instrumentation/nocode/NocodeInstrumentationTest.java
@@ -35,8 +35,7 @@ class NocodeInstrumentationTest {
   @Test
   void testBasicMethod() {
     new SampleClass().doSomething();
-    // FIXME what is scope version verification and why doesn't it pass?
-    testing.waitAndAssertTracesWithoutScopeVersionVerification(
+    testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -50,7 +49,7 @@ class NocodeInstrumentationTest {
   @Test
   void testRuleWithManyInvalidFields() {
     new SampleClass().doInvalidRule();
-    testing.waitAndAssertTracesWithoutScopeVersionVerification(
+    testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->
@@ -68,7 +67,7 @@ class NocodeInstrumentationTest {
       // nop
     }
 
-    testing.waitAndAssertTracesWithoutScopeVersionVerification(
+    testing.waitAndAssertTraces(
         trace ->
             trace.hasSpansSatisfyingExactly(
                 span ->


### PR DESCRIPTION
Let muzzle plugin find helper classes, read yaml file location from configuration object to support both system properties and environment variables, fix scope verification in tests.